### PR TITLE
Feature/auth service

### DIFF
--- a/src/components/global/globalState.ts
+++ b/src/components/global/globalState.ts
@@ -1,9 +1,17 @@
-import { createGlobalSignal } from  "sigment"
+import { createGlobalSignal } from "sigment"
 
 createGlobalSignal('userName', '');
 createGlobalSignal('userMail', '');
+createGlobalSignal('isAuthenticated', false);
+createGlobalSignal('user', null);
+createGlobalSignal('authToken', '');
+createGlobalSignal('showLoginForm', false);
 
 export const GlobalKeys = {
   userName: 'userName',
-  userMail: 'userMail'
+  userMail: 'userMail',
+  isAuthenticated: 'isAuthenticated',
+  user: 'user',
+  authToken: 'authToken',
+  showLoginForm: 'showLoginForm'
 };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -13,7 +13,8 @@ export interface AuthResponse
   }> {}
 
 export class AuthService {
-  private static readonly API_BASE_URL = "http://localhost:3003/api";
+  private static readonly API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL || "http://localhost:3003/api";
 
   static async login(credentials: LoginCredentials): Promise<AuthResponse> {
     try {
@@ -43,7 +44,6 @@ export class AuthService {
           GlobalKeys.showLoginForm
         );
 
-        // Only update if values have changed to avoid unnecessary re-renders
         if (!isAuthenticated()) {
           setIsAuthenticated(true as any);
         }
@@ -105,6 +105,8 @@ export class AuthService {
     );
     const [user, setUser] = signal(GlobalKeys.user);
     const [authToken, setAuthToken] = signal(GlobalKeys.authToken);
+
+    // Only update if values have changed to avoid unnecessary re-renders
     if (isAuthenticated()) {
       setIsAuthenticated(false as any);
     }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,124 @@
+import { GlobalKeys } from "../components/global/globalState";
+import { User, ApiResponse } from "../types";
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse
+  extends ApiResponse<{
+    user: User;
+    token: string;
+  }> {}
+
+export class AuthService {
+  private static readonly API_BASE_URL = "http://localhost:3003/api";
+
+  static async login(credentials: LoginCredentials): Promise<AuthResponse> {
+    try {
+      const response = await fetch(`${this.API_BASE_URL}/auth/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(credentials),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data: AuthResponse = await response.json();
+
+      if (data.success && data.data) {
+        // Update global state
+        const { signal } = await import("sigment");
+        const [isAuthenticated, setIsAuthenticated] = signal(
+          GlobalKeys.isAuthenticated
+        );
+        const [user, setUser] = signal(GlobalKeys.user);
+        const [authToken, setAuthToken] = signal(GlobalKeys.authToken);
+        const [showLoginForm, setShowLoginForm] = signal(
+          GlobalKeys.showLoginForm
+        );
+
+        // Only update if values have changed to avoid unnecessary re-renders
+        if (!isAuthenticated()) {
+          setIsAuthenticated(true as any);
+        }
+        if (!user() || (user() as any)?.id !== data.data.user.id) {
+          setUser(data.data.user as any);
+        }
+        if (authToken() !== data.data.token) {
+          setAuthToken(data.data.token);
+        }
+        if (showLoginForm()) {
+          setShowLoginForm(false as any);
+        }
+      }
+
+      return data;
+    } catch (error) {
+      console.error("Login error:", error);
+      throw new Error("Failed to login. Please check your credentials.");
+    }
+  }
+
+  static async getCurrentUser(): Promise<User | null> {
+    try {
+      const { signal } = await import("sigment");
+      const [authToken] = signal(GlobalKeys.authToken);
+
+      if (!authToken()) {
+        return null;
+      }
+
+      const response = await fetch(`${this.API_BASE_URL}/auth/me`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${authToken()}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (data.success && data.data) {
+        return data.data.user;
+      }
+
+      return null;
+    } catch (error) {
+      console.error("Get current user error:", error);
+      return null;
+    }
+  }
+
+  static async logout(): Promise<void> {
+    const { signal } = await import("sigment");
+    const [isAuthenticated, setIsAuthenticated] = signal(
+      GlobalKeys.isAuthenticated
+    );
+    const [user, setUser] = signal(GlobalKeys.user);
+    const [authToken, setAuthToken] = signal(GlobalKeys.authToken);
+    if (isAuthenticated()) {
+      setIsAuthenticated(false as any);
+    }
+    if (user() !== null) {
+      setUser(null as any);
+    }
+    if (authToken() !== "") {
+      setAuthToken("");
+    }
+  }
+
+  static async getAuthToken(): Promise<string> {
+    const { signal } = await import("sigment");
+    const [authToken] = signal(GlobalKeys.authToken);
+    return authToken();
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
# Feature: Update AuthService to use environment variables and improve type safety

This pull request updates the AuthService to use environment variables instead of hardcoded URLs and improves type safety throughout the authentication service.

## Changes Made

### Environment Configuration
- **Updated API_BASE_URL**: Replaced hardcoded `http://localhost:3003/api` with `import.meta.env.VITE_API_BASE_URL`
- **Added fallback**: Includes fallback to default URL if environment variable is not set
- **TypeScript support**: Added `ImportMetaEnv` interface in `vite-env.d.ts` for proper TypeScript support

### Type Safety Improvements
- **Removed duplicate interfaces**: Eliminated redeclared `User` and `AuthResponse` interfaces
- **Used existing types**: Now imports `User` and `ApiResponse` from `../types` instead of redefining them
- **Proper type inheritance**: `AuthResponse` now extends `ApiResponse<{ user: User; token: string; }>`

### Code Quality Enhancements
- **Proper destructuring**: Updated to use both getter and setter from signal destructuring
- **Conditional updates**: Added checks to prevent unnecessary state updates and re-renders
- **Error handling**: Improved null checks for API responses (`data.success && data.data`)
- **Clean code**: Removed unused variables and improved code efficiency

### State Management Optimization
- **Login method**: Only updates state if values have actually changed
- **Logout method**: Conditional state updates based on current values
- **Performance**: Prevents unnecessary re-renders by checking current state before updating

## Technical Details

### Before
```typescript
private static readonly API_BASE_URL = 'http://localhost:3003/api';

export interface User { /* duplicate interface */ }
export interface AuthResponse { /* duplicate interface */ }

const [, setIsAuthenticated] = signal(GlobalKeys.isAuthenticated); // unused getter
```

### After
```typescript
private static readonly API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3003/api';

import { User, ApiResponse } from '../types';
export interface AuthResponse extends ApiResponse<{ user: User; token: string; }> {}

const [isAuthenticated, setIsAuthenticated] = signal(GlobalKeys.isAuthenticated);
if (!isAuthenticated()) {
    setIsAuthenticated(true as any);
}
```

## Files Modified
- `src/services/authService.ts` - Main authentication service updates
- `src/vite-env.d.ts` - Added TypeScript environment variable support

## Environment Variables
- `VITE_API_BASE_URL` - API base URL for frontend requests (defaults to `http://localhost:3003/api`)

## Benefits
- **Configurability**: API URL can now be changed via environment variables
- **Type Safety**: Proper TypeScript support for environment variables
- **Code Reuse**: Uses existing type definitions instead of duplicating them
- **Performance**: Optimized state updates prevent unnecessary re-renders
- **Maintainability**: Cleaner code with proper error handling and conditional updates