### PR TITLE
Promote Dev to Main(Delete Article)

### DIFF
--- a/src/assets/css/articles.css
+++ b/src/assets/css/articles.css
@@ -192,6 +192,9 @@
   backdrop-filter: blur(10px);
   position: relative;
   animation: slideInFromLeft 0.6s ease-out both;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .article-card:nth-child(even) {
@@ -236,6 +239,9 @@
 .article-content {
   padding: var(--spacing-xl);
   position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 /* Article Meta */
@@ -388,7 +394,7 @@
 
 /* Article Actions */
 .article-actions {
-  margin-top: var(--spacing-lg);
+  margin-top: auto;
   padding-top: var(--spacing-md);
   border-top: 1px solid rgba(229, 231, 235, 0.3);
   display: flex;

--- a/src/assets/css/articles.css
+++ b/src/assets/css/articles.css
@@ -386,6 +386,40 @@
   margin-top: var(--spacing-md);
 }
 
+/* Article Actions */
+.article-actions {
+  margin-top: var(--spacing-lg);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid rgba(229, 231, 235, 0.3);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.delete-btn {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  color: var(--color-white);
+  border: none;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.delete-btn:hover {
+  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
+}
+
+.delete-btn:active {
+  transform: translateY(0);
+}
+
 .tag {
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-md);

--- a/src/components/global/globalState.ts
+++ b/src/components/global/globalState.ts
@@ -1,8 +1,10 @@
 import { signal } from "sigment";
+import type { User } from "../../types";
+
 export const [userName, setUserName] = signal("");
 export const [userMail, setUserMail] = signal("");
 export const [isAuthenticated, setIsAuthenticated] = signal(false);
-export const [user, setUser] = signal(null);
+export const [user, setUser] = signal<User | null>(null);
 export const [authToken, setAuthToken] = signal("");
 export const [showLoginForm, setShowLoginForm] = signal(false);
 export const [showCreateArticleForm, setShowCreateArticleForm] = signal(false);

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -75,4 +75,19 @@ export class ApiArticleService {
     const result = await response.json();
     return result.data;
   }
+
+  // DELETE - Delete article by ID
+  static async deleteArticle(articleId: string, authToken: string): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/articles/${articleId}`, {
+      method: "DELETE",
+      headers: {
+        "Authorization": `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete article: ${response.statusText}`);
+    }
+  }
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -16,7 +16,7 @@ export interface AuthResponse
   extends ApiResponse<{
     user: User;
     token: string;
-  }> {}
+  }> { }
 
 export class AuthService {
   private static readonly API_BASE_URL =
@@ -45,7 +45,7 @@ export class AuthService {
       if (data.success && data.data) {
         // Update global state using imported signals
         setIsAuthenticated(true);
-        setUser(data.data.user as any);
+        setUser(data.data.user);
         setAuthToken(data.data.token);
         setShowLoginForm(false);
 
@@ -149,7 +149,7 @@ export class AuthService {
           const data = await response.json();
           if (data.success && data.data) {
             setIsAuthenticated(true);
-            setUser(data.data.user as any);
+            setUser(data.data.user);
             setAuthToken(authData.token);
             return;
           }


### PR DESCRIPTION
# Promote Dev to Main(Delete Article)

This pull request adds the ability for authenticated users to delete their own articles from the article list, along with related UI and state management improvements. The main changes include backend integration for article deletion, conditional rendering of a delete button, and associated CSS styling.

**Feature: Article Deletion**

* Added a `deleteArticle` method to `ApiArticleService` to support deleting articles via API with authentication.
* Implemented `handleDeleteArticle` and `canDeleteArticle` functions in `Articles.ts` to handle the deletion flow and permission checks, and updated the article list to show a delete button only for articles authored by the current user. [[1]](diffhunk://#diff-51fbd288173aa304ea9888719a50ed9ffcfab68fad7b0ad2c6cdd3baad304102R70-R95) [[2]](diffhunk://#diff-51fbd288173aa304ea9888719a50ed9ffcfab68fad7b0ad2c6cdd3baad304102R198-R214)
* Updated global state types for `user` to ensure type safety.
* Ensured that user state is set with the correct type after authentication and token refresh in `AuthService`. [[1]](diffhunk://#diff-71c871b06f9d31277b350b7398a367e8a8ea025f2e5493bc08483c573fce0029L48-R48) [[2]](diffhunk://#diff-71c871b06f9d31277b350b7398a367e8a8ea025f2e5493bc08483c573fce0029L152-R152)

**UI/Styling Improvements**

* Enhanced the article card and content layouts to support the new action area, and added styles for the delete button and action section in `articles.css`. [[1]](diffhunk://#diff-e845d5133f8c6c74b90b083795e6ae05d52bc9f39af5449bf3559514f2c2f8b0R195-R197) [[2]](diffhunk://#diff-e845d5133f8c6c74b90b083795e6ae05d52bc9f39af5449bf3559514f2c2f8b0R242-R244) [[3]](diffhunk://#diff-e845d5133f8c6c74b90b083795e6ae05d52bc9f39af5449bf3559514f2c2f8b0R395-R428)