### PR TITLE
fix: Updated backend port in README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Create a `.env` file:
 ```bash
 DATABASE_URL="postgresql://username:password@localhost:5432/sigment_articles"
 JWT_SECRET="your-super-secret-jwt-key-here"
-PORT=3001
+PORT=3003
 NODE_ENV=development
 ```
 
@@ -167,7 +167,7 @@ sigment-article-hub/
 ## 🌐 URLs
 
 - **Frontend**: http://localhost:5173
-- **Backend API**: http://localhost:3001
+- **Backend API**: http://localhost:3003
 - **Prisma Studio**: http://localhost:5555
 
 ## 📚 Documentation
@@ -183,7 +183,7 @@ sigment-article-hub/
 - 🌐 **GitHub**: [@RileyManda](https://github.com/RileyManda)
 - 💼 **LinkedIn**: [rileymanda](https://www.linkedin.com/in/rileymanda/)
 - 🤔 **Stack Overflow**: [RileyManda](https://stackoverflow.com/users/6129553/rileymanda)
-
+git c
 ## 📄 License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
This pull request updates the backend port configuration in the documentation to ensure consistency across the project. It also includes a minor accidental addition.

Configuration and documentation updates:

* Changed the backend API port from `3001` to `3003` in the `.env` file example and in the listed URLs to match the current backend server configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R80) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R170)

Other changes:

* Accidentally added a stray line (`git c`) in the README, which should likely be removed.